### PR TITLE
feat: Adiciona /api como prefixo em todos os RestControllers

### DIFF
--- a/backend/src/main/java/com/borathings/borapagar/config/WebConfig.java
+++ b/backend/src/main/java/com/borathings/borapagar/config/WebConfig.java
@@ -1,0 +1,21 @@
+package com.borathings.borapagar.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.method.HandlerTypePredicate;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/** WebConfig Classe responsável por configurar coisas relacionadas ao Spring MVC */
+@Configuration
+@EnableWebMvc
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    /**
+     * Adiciona o prefixo "/api" à todos os controllers que utilizam da annotation @RestController
+     */
+    public void configurePathMatch(PathMatchConfigurer configurer) {
+        configurer.addPathPrefix("api", HandlerTypePredicate.forAnnotation(RestController.class));
+    }
+}

--- a/backend/src/test/java/com/borathings/borapagar/course/CourseControllerTests.java
+++ b/backend/src/test/java/com/borathings/borapagar/course/CourseControllerTests.java
@@ -60,7 +60,7 @@ public class CourseControllerTests {
     @Test
     public void shouldReturnCourses() throws Exception {
         this.mockMvc
-                .perform(get("/course"))
+                .perform(get("/api/course"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$[0].id").value(course.getId()))
@@ -71,7 +71,7 @@ public class CourseControllerTests {
     @Test
     public void shouldReturnCourseById() throws Exception {
         this.mockMvc
-                .perform(get("/course/1"))
+                .perform(get("/api/course/1"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.id").value(course.getId()))
@@ -83,7 +83,7 @@ public class CourseControllerTests {
     public void shouldCreateCourse() throws Exception {
         this.mockMvc
                 .perform(
-                        post("/course")
+                        post("/api/course")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(
                                         objectMapper.writeValueAsString(
@@ -98,7 +98,7 @@ public class CourseControllerTests {
     @Test
     public void shouldValidateFieldsOnCreate() throws Exception {
         this.mockMvc
-                .perform(post("/course").contentType(MediaType.APPLICATION_JSON).content("{}"))
+                .perform(post("/api/course").contentType(MediaType.APPLICATION_JSON).content("{}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.fieldErrors.name").value(hasSize(1)))
                 .andExpect(jsonPath("$.fieldErrors.coordinator").value(hasSize(1)));
@@ -108,7 +108,7 @@ public class CourseControllerTests {
     public void shouldUpdateCourse() throws Exception {
         this.mockMvc
                 .perform(
-                        put("/course/1")
+                        put("/api/course/1")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(
                                         objectMapper.writeValueAsString(
@@ -123,7 +123,7 @@ public class CourseControllerTests {
     @Test
     public void shouldValidateFieldsOnUpdate() throws Exception {
         this.mockMvc
-                .perform(put("/course/1").contentType(MediaType.APPLICATION_JSON).content("{}"))
+                .perform(put("/api/course/1").contentType(MediaType.APPLICATION_JSON).content("{}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.fieldErrors.name").value(hasSize(1)))
                 .andExpect(jsonPath("$.fieldErrors.coordinator").value(hasSize(1)));
@@ -131,13 +131,13 @@ public class CourseControllerTests {
 
     @Test
     public void shouldDeleteCourse() throws Exception {
-        this.mockMvc.perform(delete("/course/1")).andExpect(status().isOk());
+        this.mockMvc.perform(delete("/api/course/1")).andExpect(status().isOk());
     }
 
     @Test
     public void shouldReturnNotFoundWhenGetNonExistentCourse() throws Exception {
         this.mockMvc
-                .perform(get("/course/2"))
+                .perform(get("/api/course/2"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.message").isNotEmpty());
     }
@@ -146,7 +146,7 @@ public class CourseControllerTests {
     public void shouldReturnNotFoundWhenUpdatingNonExistentCourse() throws Exception {
         this.mockMvc
                 .perform(
-                        put("/course/2")
+                        put("/api/course/2")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(
                                         objectMapper.writeValueAsString(

--- a/backend/src/test/java/com/borathings/borapagar/ping/PingControllerTests.java
+++ b/backend/src/test/java/com/borathings/borapagar/ping/PingControllerTests.java
@@ -18,7 +18,7 @@ public class PingControllerTests {
     @Test
     public void shouldReturnPong() throws Exception {
         this.mockMvc
-                .perform(get("/ping"))
+                .perform(get("/api/ping"))
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString("Pong")));
     }
@@ -26,7 +26,7 @@ public class PingControllerTests {
     @Test
     public void shouldReturnNPongs() throws Exception {
         this.mockMvc
-                .perform(get("/pings").param("quantity", "3"))
+                .perform(get("/api/pings").param("quantity", "3"))
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString("[\"pong\",\"pong\",\"pong\"]")));
     }

--- a/backend/src/test/java/com/borathings/borapagar/subject/SubjectControllerTests.java
+++ b/backend/src/test/java/com/borathings/borapagar/subject/SubjectControllerTests.java
@@ -54,7 +54,7 @@ public class SubjectControllerTests {
     @Test
     public void shouldListAllSubjects() throws Exception {
         this.mockMvc
-                .perform(get("/subject"))
+                .perform(get("/api/subject"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$[0].id").value(subject.getId()))
@@ -67,7 +67,7 @@ public class SubjectControllerTests {
     @Test
     public void shouldListSubject() throws Exception {
         this.mockMvc
-                .perform(get("/subject/1"))
+                .perform(get("/api/subject/1"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.id").value(subject.getId()))
@@ -80,7 +80,7 @@ public class SubjectControllerTests {
     @Test
     public void shouldReturnNotFoundWhenGetNonExistentSubject() throws Exception {
         this.mockMvc
-                .perform(get("/subject/2"))
+                .perform(get("/api/subject/2"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.message").isNotEmpty());
     }
@@ -89,7 +89,7 @@ public class SubjectControllerTests {
     public void shouldCreateSubject() throws Exception {
         this.mockMvc
                 .perform(
-                        post("/subject")
+                        post("/api/subject")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(
                                         objectMapper.writeValueAsString(
@@ -110,7 +110,7 @@ public class SubjectControllerTests {
     @Test
     public void shouldValidateFieldsOnCreate() throws Exception {
         this.mockMvc
-                .perform(post("/subject").contentType(MediaType.APPLICATION_JSON).content("{}"))
+                .perform(post("/api/subject").contentType(MediaType.APPLICATION_JSON).content("{}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.fieldErrors.name").isNotEmpty())
@@ -119,7 +119,7 @@ public class SubjectControllerTests {
 
         this.mockMvc
                 .perform(
-                        post("/subject")
+                        post("/api/subject")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(
                                         objectMapper.writeValueAsString(
@@ -131,7 +131,7 @@ public class SubjectControllerTests {
     public void shouldUpdateSubject() throws Exception {
         this.mockMvc
                 .perform(
-                        put("/subject/1")
+                        put("/api/subject/1")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(
                                         objectMapper.writeValueAsString(
@@ -149,7 +149,7 @@ public class SubjectControllerTests {
     public void shouldReturnNotFoundWhenUpdatingNonExistentSubject() throws Exception {
         this.mockMvc
                 .perform(
-                        put("/subject/2")
+                        put("/api/subject/2")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(
                                         objectMapper.writeValueAsString(
@@ -161,7 +161,8 @@ public class SubjectControllerTests {
     @Test
     public void shouldValidateFieldsOnUpdate() throws Exception {
         this.mockMvc
-                .perform(put("/subject/1").contentType(MediaType.APPLICATION_JSON).content("{}"))
+                .perform(
+                        put("/api/subject/1").contentType(MediaType.APPLICATION_JSON).content("{}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.fieldErrors.name").isNotEmpty())
@@ -170,7 +171,7 @@ public class SubjectControllerTests {
 
         this.mockMvc
                 .perform(
-                        put("/subject/1")
+                        put("/api/subject/1")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(
                                         objectMapper.writeValueAsString(
@@ -180,6 +181,6 @@ public class SubjectControllerTests {
 
     @Test
     public void shouldDeleteSubject() throws Exception {
-        this.mockMvc.perform(delete("/subject/1")).andExpect(status().isOk());
+        this.mockMvc.perform(delete("/api/subject/1")).andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
**Por favor, informe se a PR segue os requisitos obrigatórios:**

- [X] Mesmo padrão de código do projeto
- [X] Arquivos alterados/adicionados seguem o padrão _Camel Case_
- [ ] A PR está relacionada a uma ou mais issue
- [ ] Relacionei todas as issues na seção de "Development" da PR
- [X] O código foi revisado uma vez ou mais

**Motivação para a criação da PR**
Separação de conceitos, todos os RestControllers terão `/api` como prefixo, isso permite adicionar exigir autenticação & autorização apenas nesses endpoints, enquanto outros não exigirão (exemplo: `oauth2/**`, `swagger/**`)


### Por que não `server.servlet.contextPath=/api` ?

Porque todos os endpoints teriam `/api` como prefixo, não apenas os controllers.

###  Por que não fazer isso em um `@AbstractController` ou similar?

Ao extender o AbstractController, utilizar o `@RequestMapping` sobreescreveria o valor atual.
Caso utilizemos uma anotação custom, toda request teria que ter o seu recurso nela, ex:

```java
@Controller
@ApiPrefixController
public class SomeController {
    @GetMapping("users/")
    @ReponseBody
    public String getAll(){
        // ...
    }
   @DeleteMapping("users/:id")
    public void delete(int id) {
     //   ...
   }
}
```

Acho preferível apenas:


```java
@Controller
@RequestMapping("/users")
public class SomeController {
    @GetMapping("/")
    @ReponseBody
    public String getAll(){
        // ...
    }
   @DeleteMapping(":id")
    public void delete(int id) {
     //   ...
   }
}
```