### PR TITLE
Mensagens de erro em português

### DIFF
--- a/backend/src/main/java/com/borathings/borapagar/core/exception/ApiException.java
+++ b/backend/src/main/java/com/borathings/borapagar/core/exception/ApiException.java
@@ -39,7 +39,7 @@ public class ApiException {
     public ApiException(HttpStatus status, Throwable ex) {
         this();
         this.status = status;
-        this.message = "Unexpected error";
+        this.message = ex.getMessage();
     }
 
     /**

--- a/backend/src/main/java/com/borathings/borapagar/core/exception/ApiFieldException.java
+++ b/backend/src/main/java/com/borathings/borapagar/core/exception/ApiFieldException.java
@@ -15,7 +15,9 @@ import org.springframework.http.HttpStatus;
 public class ApiFieldException extends ApiException {
     public ApiFieldException(HttpStatus status, Map<String, List<String>> fieldErrors) {
         super(status);
-        this.setMessage("One or more fields are invalid, check fieldErrors for more information");
+        this.setMessage(
+                "Um ou mais campos falharam na validação. Verifique o atributo fieldErrors para"
+                        + " mais detalhes.");
         this.fieldErrors = fieldErrors;
     }
 

--- a/backend/src/main/java/com/borathings/borapagar/core/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/borathings/borapagar/core/exception/GlobalExceptionHandler.java
@@ -36,7 +36,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      */
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Object> handleGenericException(Exception ex) {
-        ApiException apiException = new ApiException(HttpStatus.INTERNAL_SERVER_ERROR, ex);
+        ApiException apiException =
+                new ApiException(HttpStatus.INTERNAL_SERVER_ERROR, "Erro inesperado", ex);
         return buildResponseEntityFromException(apiException);
     }
 
@@ -48,9 +49,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      */
     @ExceptionHandler(EntityNotFoundException.class)
     public ResponseEntity<Object> handleEntityNotFoundException(EntityNotFoundException ex) {
-        ApiException apiException =
-                new ApiException(
-                        HttpStatus.NOT_FOUND, "entity with the requested id does not exist", ex);
+        ApiException apiException = new ApiException(HttpStatus.NOT_FOUND, ex);
         return buildResponseEntityFromException(apiException);
     }
 

--- a/backend/src/main/java/com/borathings/borapagar/course/CourseService.java
+++ b/backend/src/main/java/com/borathings/borapagar/course/CourseService.java
@@ -39,7 +39,7 @@ public class CourseService {
     public CourseEntity getCourseById(Long id) {
         CourseEntity courseEntity = courseRepository.findById(id).orElse(null);
         if (courseEntity == null) {
-            throw new EntityNotFoundException("Course of id " + id + " not found");
+            throw new EntityNotFoundException("Curso com id " + id + " não encontrado");
         }
         return courseEntity;
     }

--- a/backend/src/main/java/com/borathings/borapagar/subject/SubjectService.java
+++ b/backend/src/main/java/com/borathings/borapagar/subject/SubjectService.java
@@ -42,7 +42,7 @@ public class SubjectService {
                         .orElseThrow(
                                 () ->
                                         new EntityNotFoundException(
-                                                "Subject with id + " + id + " not found"));
+                                                "Disciplina com id " + id + " não encontrada"));
         return subject;
     }
 

--- a/backend/src/main/resources/ValidationMessages.properties
+++ b/backend/src/main/resources/ValidationMessages.properties
@@ -1,0 +1,4 @@
+jakarta.validation.constraints.NotEmpty.message=O campo é obrigatório
+jakarta.validation.constraints.NotNull.message=O campo é obrigatório
+jakarta.validation.constraints.NotBlank.message=Campo não pode estar em branco
+jakarta.validation.constraints.Min.message=Campo deve ser maior ou igual a {value}

--- a/backend/src/test/java/com/borathings/borapagar/course/CourseControllerTests.java
+++ b/backend/src/test/java/com/borathings/borapagar/course/CourseControllerTests.java
@@ -48,11 +48,13 @@ public class CourseControllerTests {
 
         when(courseService.getAllCourses()).thenReturn(List.of(course));
         when(courseService.getCourseById(eq(1L))).thenReturn(course);
-        when(courseService.getCourseById(eq(2L))).thenThrow(EntityNotFoundException.class);
+        when(courseService.getCourseById(eq(2L)))
+                .thenThrow(new EntityNotFoundException("Curso não encontrado"));
 
         when(courseService.createCourse(any())).thenReturn(course);
         when(courseService.updateCourse(eq(1L), any())).thenReturn(course);
-        when(courseService.updateCourse(eq(2L), any())).thenThrow(EntityNotFoundException.class);
+        when(courseService.updateCourse(eq(2L), any()))
+                .thenThrow(new EntityNotFoundException("Curso não encontrado"));
         doNothing().when(courseService).deleteCourse(eq(1L));
         ;
     }

--- a/backend/src/test/java/com/borathings/borapagar/course/CourseServiceTests.java
+++ b/backend/src/test/java/com/borathings/borapagar/course/CourseServiceTests.java
@@ -32,7 +32,8 @@ public class CourseServiceTests {
 
         when(courseRepository.findAll()).thenReturn(List.of(course));
         when(courseRepository.findById(1L)).thenReturn(Optional.of(course));
-        when(courseRepository.findById(2L)).thenThrow(EntityNotFoundException.class);
+        when(courseRepository.findById(2L))
+                .thenThrow(new EntityNotFoundException("Curso não encontrado"));
         when(courseRepository.save(course)).thenReturn(course);
         doNothing().when(courseRepository).deleteById(1L);
     }

--- a/backend/src/test/java/com/borathings/borapagar/subject/SubjectControllerTests.java
+++ b/backend/src/test/java/com/borathings/borapagar/subject/SubjectControllerTests.java
@@ -44,10 +44,12 @@ public class SubjectControllerTests {
 
         when(subjectService.findAll()).thenReturn(List.of(subject));
         when(subjectService.findById(1L)).thenReturn(subject);
-        when(subjectService.findById(2L)).thenThrow(EntityNotFoundException.class);
+        when(subjectService.findById(2L))
+                .thenThrow(new EntityNotFoundException("Disciplina não encontrada"));
         when(subjectService.create(any())).thenReturn(subject);
         when(subjectService.update(eq(1L), any())).thenReturn(subject);
-        when(subjectService.update(eq(2L), any())).thenThrow(EntityNotFoundException.class);
+        when(subjectService.update(eq(2L), any()))
+                .thenThrow(new EntityNotFoundException("Disciplina não encontrada"));
         doNothing().when(subjectService).delete(1L);
     }
 

--- a/backend/src/test/java/com/borathings/borapagar/subject/SubjectServiceTests.java
+++ b/backend/src/test/java/com/borathings/borapagar/subject/SubjectServiceTests.java
@@ -30,7 +30,8 @@ public class SubjectServiceTests {
 
         when(subjectRepository.findAll()).thenReturn(List.of(subject));
         when(subjectRepository.findById(1L)).thenReturn(Optional.of(subject));
-        when(subjectRepository.findById(2L)).thenThrow(EntityNotFoundException.class);
+        when(subjectRepository.findById(2L))
+                .thenThrow(new EntityNotFoundException("Disciplina não encontrada"));
         when(subjectRepository.save(subject)).thenReturn(subject);
         doNothing().when(subjectRepository).deleteById(1L);
     }


### PR DESCRIPTION
**Por favor, informe se a PR segue os requisitos obrigatórios:**
<!--- Exemplo checkbox marcado: - [x] -->

- [x] Mesmo padrão de código do projeto
- [x] Arquivos alterados/adicionados seguem o padrão _Camel Case_
- [x] A PR está relacionada a uma ou mais issue
- [x] Relacionei todas as issues na seção de "Development" da PR
- [x] O código foi revisado uma vez ou mais

**Motivação para a criação da PR**
<!---Descreva de maneira clara e concisa a motivação para a criação da PR na linha abaixo.-->
Nossos usuários falam português e portanto as mensagens de erros precisam ser claras para eles.
closes #39 

**O que foi feito**
- Tradução das mensagens de erro para português.
- Mudança dos construtores da api exception pois as mensagens de EntityNotFound estavam sendo sobrescrevidas por uma mensagem padrão
- Adição do arquivo `ValidationMessages.properties` para customizar as mensagens de validação padrão. Assim elas ficam em português 
