### PR TITLE
Refatoração nos services

### DIFF
--- a/backend/src/main/java/com/borathings/borapagar/course/CourseService.java
+++ b/backend/src/main/java/com/borathings/borapagar/course/CourseService.java
@@ -16,7 +16,7 @@ public class CourseService {
      * @param courseEntity - Entidade do curso
      * @return Curso criado
      */
-    public CourseEntity createCourse(CourseEntity courseEntity) {
+    public CourseEntity create(CourseEntity courseEntity) {
         return courseRepository.save(courseEntity);
     }
 
@@ -25,22 +25,25 @@ public class CourseService {
      *
      * @return Lista de cursos
      */
-    public List<CourseEntity> getAllCourses() {
+    public List<CourseEntity> findAll() {
         return courseRepository.findAll();
     }
 
     /**
-     * Retorna um curso pelo id
+     * Retorna um curso pelo id. Lança uma exceção caso o curso não seja encontrado
      *
      * @param id - Id do curso
      * @return Curso recuperado
      * @throws EntityNotFoundException - Caso o curso não seja encontrado
      */
-    public CourseEntity getCourseById(Long id) {
-        CourseEntity courseEntity = courseRepository.findById(id).orElse(null);
-        if (courseEntity == null) {
-            throw new EntityNotFoundException("Course of id " + id + " not found");
-        }
+    public CourseEntity findByIdOrError(Long id) {
+        CourseEntity courseEntity =
+                courseRepository
+                        .findById(id)
+                        .orElseThrow(
+                                () ->
+                                        new EntityNotFoundException(
+                                                "Curso com id " + id + " não encontrado"));
         return courseEntity;
     }
 
@@ -52,8 +55,8 @@ public class CourseService {
      * @return Curso atualizado
      * @throws EntityNotFoundException - Caso o curso não seja encontrado
      */
-    public CourseEntity updateCourse(Long id, CourseEntity courseEntity) {
-        getCourseById(id);
+    public CourseEntity update(Long id, CourseEntity courseEntity) {
+        findByIdOrError(id);
         courseEntity.setId(id);
         return courseRepository.save(courseEntity);
     }
@@ -63,7 +66,7 @@ public class CourseService {
      *
      * @param id - Id do curso
      */
-    public void deleteCourse(Long id) {
+    public void delete(Long id) {
         courseRepository.deleteById(id);
     }
 }

--- a/backend/src/main/java/com/borathings/borapagar/course/impl/CourseControllerImpl.java
+++ b/backend/src/main/java/com/borathings/borapagar/course/impl/CourseControllerImpl.java
@@ -20,27 +20,27 @@ public class CourseControllerImpl implements CourseController {
     public ResponseEntity<CourseEntity> createCourse(
             @Valid @RequestBody CourseDTO courseEntityDto) {
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(courseService.createCourse(courseEntityDto.toEntity()));
+                .body(courseService.create(courseEntityDto.toEntity()));
     }
 
     @Override
     public ResponseEntity<List<CourseEntity>> getAllCourses() {
-        return ResponseEntity.ok(courseService.getAllCourses());
+        return ResponseEntity.ok(courseService.findAll());
     }
 
     @Override
     public ResponseEntity<CourseEntity> getCourseById(Long id) {
-        return ResponseEntity.ok(courseService.getCourseById(id));
+        return ResponseEntity.ok(courseService.findByIdOrError(id));
     }
 
     @Override
     public ResponseEntity<CourseEntity> updateCourse(CourseDTO courseEntityDto, Long id) {
-        return ResponseEntity.ok(courseService.updateCourse(id, courseEntityDto.toEntity()));
+        return ResponseEntity.ok(courseService.update(id, courseEntityDto.toEntity()));
     }
 
     @Override
     public ResponseEntity<String> deleteCourse(Long id) {
-        courseService.deleteCourse(id);
-        return ResponseEntity.ok("Course deleted successfully");
+        courseService.delete(id);
+        return ResponseEntity.ok("Curso deletado com sucesso");
     }
 }

--- a/backend/src/main/java/com/borathings/borapagar/subject/SubjectService.java
+++ b/backend/src/main/java/com/borathings/borapagar/subject/SubjectService.java
@@ -12,7 +12,7 @@ public class SubjectService {
     /**
      * Salva uma nova disciplina no banco de dados
      *
-     * @param subjectDto - Dados da disciplina
+     * @param subjectEntity - Dados da disciplina
      * @return Disciplina salva
      */
     public SubjectEntity create(SubjectEntity subjectEntity) {
@@ -50,7 +50,7 @@ public class SubjectService {
      * Atualiza os dados de uma disciplina
      *
      * @param id - Id da disciplina
-     * @param subjectDto - Novos dados da disciplina
+     * @param subjectEntity - Novos dados da disciplina
      * @throws EntityNotFoundException se a disciplina não existir
      * @return Disciplina atualizada
      */

--- a/backend/src/main/java/com/borathings/borapagar/subject/SubjectService.java
+++ b/backend/src/main/java/com/borathings/borapagar/subject/SubjectService.java
@@ -29,13 +29,13 @@ public class SubjectService {
     }
 
     /**
-     * Busca uma disciplina pelo id.
+     * Busca uma disciplina pelo id. Lança uma exceção caso a disciplina não seja encontrada
      *
      * @throws EntityNotFoundException se a disciplina não existir
      * @param id
      * @return Disciplina encontrada
      */
-    public SubjectEntity findById(Long id) {
+    public SubjectEntity findByIdOrError(Long id) {
         SubjectEntity subject =
                 subjectRepository
                         .findById(id)
@@ -55,7 +55,7 @@ public class SubjectService {
      * @return Disciplina atualizada
      */
     public SubjectEntity update(Long id, SubjectEntity subjectEntity) {
-        findById(id);
+        findByIdOrError(id);
         subjectEntity.setId(id);
         return subjectRepository.save(subjectEntity);
     }

--- a/backend/src/main/java/com/borathings/borapagar/subject/impl/SubjectControllerImpl.java
+++ b/backend/src/main/java/com/borathings/borapagar/subject/impl/SubjectControllerImpl.java
@@ -28,7 +28,7 @@ public class SubjectControllerImpl implements SubjectController {
 
     @Override
     public ResponseEntity<SubjectEntity> getSubjectById(Long id) {
-        return ResponseEntity.ok(subjectService.findById(id));
+        return ResponseEntity.ok(subjectService.findByIdOrError(id));
     }
 
     @Override
@@ -39,6 +39,6 @@ public class SubjectControllerImpl implements SubjectController {
     @Override
     public ResponseEntity<String> deleteSubject(Long id) {
         subjectService.delete(id);
-        return ResponseEntity.ok("Subject deleted successfully");
+        return ResponseEntity.ok("Disciplina excluída com sucesso");
     }
 }

--- a/backend/src/test/java/com/borathings/borapagar/course/CourseControllerTests.java
+++ b/backend/src/test/java/com/borathings/borapagar/course/CourseControllerTests.java
@@ -46,14 +46,14 @@ public class CourseControllerTests {
         course.setId(1L);
         course.setDeleted(false);
 
-        when(courseService.getAllCourses()).thenReturn(List.of(course));
-        when(courseService.getCourseById(eq(1L))).thenReturn(course);
-        when(courseService.getCourseById(eq(2L))).thenThrow(EntityNotFoundException.class);
+        when(courseService.findAll()).thenReturn(List.of(course));
+        when(courseService.findByIdOrError(eq(1L))).thenReturn(course);
+        when(courseService.findByIdOrError(eq(2L))).thenThrow(EntityNotFoundException.class);
 
-        when(courseService.createCourse(any())).thenReturn(course);
-        when(courseService.updateCourse(eq(1L), any())).thenReturn(course);
-        when(courseService.updateCourse(eq(2L), any())).thenThrow(EntityNotFoundException.class);
-        doNothing().when(courseService).deleteCourse(eq(1L));
+        when(courseService.create(any())).thenReturn(course);
+        when(courseService.update(eq(1L), any())).thenReturn(course);
+        when(courseService.update(eq(2L), any())).thenThrow(EntityNotFoundException.class);
+        doNothing().when(courseService).delete(eq(1L));
         ;
     }
 

--- a/backend/src/test/java/com/borathings/borapagar/course/CourseServiceTests.java
+++ b/backend/src/test/java/com/borathings/borapagar/course/CourseServiceTests.java
@@ -39,27 +39,27 @@ public class CourseServiceTests {
 
     @Test
     public void shouldCreateCourse() {
-        CourseEntity createdCourse = courseService.createCourse(course);
+        CourseEntity createdCourse = courseService.create(course);
         assert createdCourse.equals(course);
     }
 
     @Test
     public void shouldGetAllCourses() {
-        List<CourseEntity> courses = courseService.getAllCourses();
+        List<CourseEntity> courses = courseService.findAll();
         assert courses.size() == 1;
         assert courses.get(0).equals(course);
     }
 
     @Test
     void shouldGetCourseById() {
-        CourseEntity course = courseService.getCourseById(1L);
+        CourseEntity course = courseService.findByIdOrError(1L);
         assert course.equals(this.course);
     }
 
     @Test
     void shouldThrowEntityNotFoundExceptionWhenRequestNonExistentCourse() {
         try {
-            courseService.getCourseById(2L);
+            courseService.findByIdOrError(2L);
         } catch (EntityNotFoundException e) {
             assert true;
             return;
@@ -72,7 +72,7 @@ public class CourseServiceTests {
     void shouldUpdateCourse() {
         CourseEntity courseCopy = course;
         courseCopy.setId(null);
-        CourseEntity updatedCourse = courseService.updateCourse(1L, courseCopy);
+        CourseEntity updatedCourse = courseService.update(1L, courseCopy);
 
         assert updatedCourse.getId().equals(1L);
         assert updatedCourse.getName().equals(courseCopy.getName());
@@ -80,7 +80,7 @@ public class CourseServiceTests {
 
     @Test
     void shouldDeleteCourse() {
-        courseService.deleteCourse(1L);
+        courseService.delete(1L);
         assert true;
     }
 
@@ -89,7 +89,7 @@ public class CourseServiceTests {
         try {
             CourseEntity courseCopy = course;
             courseCopy.setId(null);
-            courseService.updateCourse(2L, courseCopy);
+            courseService.update(2L, courseCopy);
         } catch (EntityNotFoundException e) {
             assert true;
             return;

--- a/backend/src/test/java/com/borathings/borapagar/subject/SubjectControllerTests.java
+++ b/backend/src/test/java/com/borathings/borapagar/subject/SubjectControllerTests.java
@@ -43,8 +43,8 @@ public class SubjectControllerTests {
                         "Matemática elementar", "IMD0001", "math and stuff", Integer.valueOf(60));
 
         when(subjectService.findAll()).thenReturn(List.of(subject));
-        when(subjectService.findById(1L)).thenReturn(subject);
-        when(subjectService.findById(2L)).thenThrow(EntityNotFoundException.class);
+        when(subjectService.findByIdOrError(1L)).thenReturn(subject);
+        when(subjectService.findByIdOrError(2L)).thenThrow(EntityNotFoundException.class);
         when(subjectService.create(any())).thenReturn(subject);
         when(subjectService.update(eq(1L), any())).thenReturn(subject);
         when(subjectService.update(eq(2L), any())).thenThrow(EntityNotFoundException.class);

--- a/backend/src/test/java/com/borathings/borapagar/subject/SubjectServiceTests.java
+++ b/backend/src/test/java/com/borathings/borapagar/subject/SubjectServiceTests.java
@@ -50,14 +50,14 @@ public class SubjectServiceTests {
 
     @Test
     void shouldGetSubjectById() {
-        SubjectEntity subject = subjectService.findById(1L);
+        SubjectEntity subject = subjectService.findByIdOrError(1L);
         assert subject.equals(this.subject);
     }
 
     @Test
     void shouldThrowEntityNotFoundExceptionWhenRequestNonExistentSubject() {
         try {
-            subjectService.findById(2L);
+            subjectService.findByIdOrError(2L);
         } catch (EntityNotFoundException e) {
             assert true;
             return;


### PR DESCRIPTION
**Por favor, informe se a PR segue os requisitos obrigatórios:**
<!--- Exemplo checkbox marcado: - [x] -->

- [x] Mesmo padrão de código do projeto
- [x] Arquivos alterados/adicionados seguem o padrão _Camel Case_
- [ ] A PR está relacionada a uma ou mais issue
- [x] Relacionei todas as issues na seção de "Development" da PR
- [x] O código foi revisado uma vez ou mais

**Motivação para a criação da PR**
<!---Descreva de maneira clara e concisa a motivação para a criação da PR na linha abaixo.-->
Por uma questão de legibilidade e manutenção é melhor usar o `.orElseThrow`. Também fiz outras mudanças que considerei pequenas demais para merecerem uma PR própria, mas que ainda assim estão relacionadas com os services. Detalho as motivações abaixo:
- Atualização da documentação: O javadoc não estava batendo com as assinaturas das funções e isso poderia gerar confusão
- Renomeação dos métodos: Nomes mais genéricos foram usados no CourseService para facilitar a implementação de uma generalização no futuro (AbstractService?). Além disso, o fato da classe se chamar CourseService deve fornecer contexto suficiente que ela realiza as operações na entidade de cursos.
- Tradução da mensagem de deleção para PT-BR: Mudança relacionada com a PR #39 que foi esquecida.


**O que foi feito**
<!---
  Se muita coisa foi feita, por favor resumir na linha abaixo.
  Exemplo:
    - Um açaí no capricho
    - Uma landing page
    - Um som que te faz dançar
-->
- Uso do `.orElseThrow()` no `CourseService`.
- Atualização da documentação dos métodos
- Renomeação dos métodos
- Tradução da mensagem de deleção para PT- BR
