### PR TITLE
Removendo assert puro dos testes

### DIFF
--- a/backend/src/test/java/com/borathings/borapagar/course/CourseControllerTests.java
+++ b/backend/src/test/java/com/borathings/borapagar/course/CourseControllerTests.java
@@ -56,7 +56,6 @@ public class CourseControllerTests {
         when(courseService.update(eq(2L), any()))
                 .thenThrow(new EntityNotFoundException("Curso não encontrado"));
         doNothing().when(courseService).delete(eq(1L));
-        ;
     }
 
     @Test

--- a/backend/src/test/java/com/borathings/borapagar/course/CourseServiceTests.java
+++ b/backend/src/test/java/com/borathings/borapagar/course/CourseServiceTests.java
@@ -1,5 +1,8 @@
 package com.borathings.borapagar.course;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
@@ -41,32 +44,25 @@ public class CourseServiceTests {
     @Test
     public void shouldCreateCourse() {
         CourseEntity createdCourse = courseService.create(course);
-        assert createdCourse.equals(course);
+        assertEquals(course, createdCourse);
     }
 
     @Test
     public void shouldGetAllCourses() {
         List<CourseEntity> courses = courseService.findAll();
-        assert courses.size() == 1;
-        assert courses.get(0).equals(course);
+        assertEquals(1, courses.size());
+        assertEquals(course, courses.get(0));
     }
 
     @Test
     void shouldGetCourseById() {
         CourseEntity course = courseService.findByIdOrError(1L);
-        assert course.equals(this.course);
+        assertEquals(this.course, course);
     }
 
     @Test
     void shouldThrowEntityNotFoundExceptionWhenRequestNonExistentCourse() {
-        try {
-            courseService.findByIdOrError(2L);
-        } catch (EntityNotFoundException e) {
-            assert true;
-            return;
-        }
-
-        assert false;
+        assertThrows(EntityNotFoundException.class, () -> courseService.findByIdOrError(2L));
     }
 
     @Test
@@ -75,27 +71,19 @@ public class CourseServiceTests {
         courseCopy.setId(null);
         CourseEntity updatedCourse = courseService.update(1L, courseCopy);
 
-        assert updatedCourse.getId().equals(1L);
-        assert updatedCourse.getName().equals(courseCopy.getName());
+        assertEquals(1L, updatedCourse.getId());
+        assertEquals(courseCopy.getName(), updatedCourse.getName());
     }
 
     @Test
     void shouldDeleteCourse() {
-        courseService.delete(1L);
-        assert true;
+        assertDoesNotThrow(() -> courseService.delete(1L));
     }
 
     @Test
     void shouldThrowEntityNotFoundExceptionWhenUpdatingNonExistentCourse() {
-        try {
-            CourseEntity courseCopy = course;
-            courseCopy.setId(null);
-            courseService.update(2L, courseCopy);
-        } catch (EntityNotFoundException e) {
-            assert true;
-            return;
-        }
-
-        assert false;
+        CourseEntity courseCopy = course;
+        courseCopy.setId(null);
+        assertThrows(EntityNotFoundException.class, () -> courseService.update(2L, courseCopy));
     }
 }

--- a/backend/src/test/java/com/borathings/borapagar/subject/SubjectServiceTests.java
+++ b/backend/src/test/java/com/borathings/borapagar/subject/SubjectServiceTests.java
@@ -1,5 +1,8 @@
 package com.borathings.borapagar.subject;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
@@ -39,32 +42,25 @@ public class SubjectServiceTests {
     @Test
     public void shouldCreateSubject() {
         SubjectEntity createdSubject = subjectService.create(subject);
-        assert createdSubject.equals(subject);
+        assertEquals(subject, createdSubject);
     }
 
     @Test
     public void shouldGetAllSubjects() {
         List<SubjectEntity> subjects = subjectService.findAll();
-        assert subjects.size() == 1;
-        assert subjects.get(0).equals(subject);
+        assertEquals(1, subjects.size());
+        assertEquals(subject, subjects.get(0));
     }
 
     @Test
     void shouldGetSubjectById() {
         SubjectEntity subject = subjectService.findByIdOrError(1L);
-        assert subject.equals(this.subject);
+        assertEquals(this.subject, subject);
     }
 
     @Test
     void shouldThrowEntityNotFoundExceptionWhenRequestNonExistentSubject() {
-        try {
-            subjectService.findByIdOrError(2L);
-        } catch (EntityNotFoundException e) {
-            assert true;
-            return;
-        }
-
-        assert false;
+        assertThrows(EntityNotFoundException.class, () -> subjectService.findByIdOrError(2L));
     }
 
     @Test
@@ -73,27 +69,19 @@ public class SubjectServiceTests {
         subjectCopy.setId(null);
         SubjectEntity updatedSubject = subjectService.update(1L, subjectCopy);
 
-        assert updatedSubject.getId().equals(1L);
-        assert updatedSubject.getName().equals(subjectCopy.getName());
+        assertEquals(1L, updatedSubject.getId());
+        assertEquals(subjectCopy.getName(), updatedSubject.getName());
     }
 
     @Test
     void shouldDeleteSubject() {
-        subjectService.delete(1L);
-        assert true;
+        assertDoesNotThrow(() -> subjectService.delete(1L));
     }
 
     @Test
     void shouldThrowEntityNotFoundExceptionWhenUpdatingNonExistentSubject() {
-        try {
-            SubjectEntity subjectCopy = subject;
-            subjectCopy.setId(null);
-            subjectService.update(2L, subjectCopy);
-        } catch (EntityNotFoundException e) {
-            assert true;
-            return;
-        }
-
-        assert false;
+        SubjectEntity subjectCopy = subject;
+        subjectCopy.setId(null);
+        assertThrows(EntityNotFoundException.class, () -> subjectService.update(2L, subjectCopy));
     }
 }


### PR DESCRIPTION
**Por favor, informe se a PR segue os requisitos obrigatórios:**
<!--- Exemplo checkbox marcado: - [x] -->

- [x] Mesmo padrão de código do projeto
- [x] Arquivos alterados/adicionados seguem o padrão _Camel Case_
- [ ] A PR está relacionada a uma ou mais issue
- [x] Relacionei todas as issues na seção de "Development" da PR
- [x] O código foi revisado uma vez ou mais

**Motivação para a criação da PR**
<!---Descreva de maneira clara e concisa a motivação para a criação da PR na linha abaixo.-->
Os testes estavam utilizando a palavra reservada `assert` do Java. Isso é uma má prática pois ele não nos fornece mensagens de erro interessantes. O `assert` foi substituido por alternativas melhores como o `assertEquals` e o `assertThrows`

**O que foi feito**
<!---
  Se muita coisa foi feita, por favor resumir na linha abaixo.
  Exemplo:
    - Um açaí no capricho
    - Uma landing page
    - Um som que te faz dançar
-->
- Remoção dos asserts puros nos testes
- Aquele ; do além também foi removido 

