### PR TITLE
Melhorando a documentação do GlobalExceptionHandler.handleMethodArgumentNotValid

### DIFF
--- a/backend/src/main/java/com/borathings/borapagar/core/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/borathings/borapagar/core/exception/GlobalExceptionHandler.java
@@ -53,6 +53,27 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return buildResponseEntityFromException(apiException);
     }
 
+    /**
+     * Trata exceções lançadas pela aplicação quando um campo falha na validação. Retorna um JSON
+     * com os campos que falharam na validação e suas respectivas mensagens de erro, seguindo a
+     * estrutura:
+     *
+     * <pre>
+     * {
+     *   [...]
+     *   "fieldErrors": {
+     *     "campo1": ["erro1", "erro2"]
+     *     [...]
+     *   }
+     * }
+     * </pre>
+     *
+     * @param ex - MethodArgumentNotValidException - Exceção lançada
+     * @param headers - HttpHeaders - Cabeçalhos da requisição que falhou na validação
+     * @param status - HttpStatusCode - Status HTTP da resposta
+     * @param request - WebRequest - Requisição que falhou na validação
+     * @return ResponseEntity<ApiFieldException> - JSON da exceção
+     */
     @Override
     protected ResponseEntity<Object> handleMethodArgumentNotValid(
             MethodArgumentNotValidException ex,

--- a/backend/src/main/java/com/borathings/borapagar/core/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/borathings/borapagar/core/exception/GlobalExceptionHandler.java
@@ -54,25 +54,20 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     /**
-     * Trata exceções lançadas pela aplicação quando um campo falha na validação. Retorna um JSON
-     * com os campos que falharam na validação e suas respectivas mensagens de erro, seguindo a
-     * estrutura:
+     * Trata exceções lançadas pela aplicação quando uma entidade falha na validação. Este método
+     * constrói uma instância da classe <code>ApiFieldException</code> extende a classe <code>
+     * ApiException</code> com os erros de validação.
      *
-     * <pre>
-     * {
-     *   [...]
-     *   "fieldErrors": {
-     *     "campo1": ["erro1", "erro2"]
-     *     [...]
-     *   }
-     * }
-     * </pre>
+     * <p>Os erros são representados pelo atributo fieldErrors, que é um mapa onde a chave é o nome
+     * do campo que falhou na validação e o valor é um vetor contendo as mensagens de todos os erros
+     * relacionados àquele campo.
      *
      * @param ex - MethodArgumentNotValidException - Exceção lançada
      * @param headers - HttpHeaders - Cabeçalhos da requisição que falhou na validação
      * @param status - HttpStatusCode - Status HTTP da resposta
      * @param request - WebRequest - Requisição que falhou na validação
-     * @return ResponseEntity<ApiFieldException> - JSON da exceção
+     * @return ResponseEntity<ApiFieldException> - Instância de ApiFieldException serializada para
+     *     JSON
      */
     @Override
     protected ResponseEntity<Object> handleMethodArgumentNotValid(


### PR DESCRIPTION
**Por favor, informe se a PR segue os requisitos obrigatórios:**
<!--- Exemplo checkbox marcado: - [x] -->

- [x] Mesmo padrão de código do projeto
- [x] Arquivos alterados/adicionados seguem o padrão _Camel Case_
- [ ] A PR está relacionada a uma ou mais issue
- [x] Relacionei todas as issues na seção de "Development" da PR
- [x] O código foi revisado uma vez ou mais

**Motivação para a criação da PR**
<!---Descreva de maneira clara e concisa a motivação para a criação da PR na linha abaixo.-->
O método do `GlobalExceptionHandler` era o único sem javadoc. Creio que é porque ele já tem um javadoc padrão. Mas mesmo assim, é melhor mudar para facilitar o entendimento da nossa equipe

**O que foi feito**
<!---
  Se muita coisa foi feita, por favor resumir na linha abaixo.
  Exemplo:
    - Um açaí no capricho
    - Uma landing page
    - Um som que te faz dançar
-->
Adicionado javadoc do `GlobalExceptionHandler.handleMethodArgumentNotValid`
