### PR TITLE
ci: Roda coverage do jacoco apenas quando houverem mudanças no backend

### DIFF
--- a/.github/workflows/backend_test_coverage.yml
+++ b/.github/workflows/backend_test_coverage.yml
@@ -2,6 +2,8 @@ name: Test Coverage
 
 on:
   pull_request:
+    paths:
+      - "backend/**"
 
 defaults:
   run:


### PR DESCRIPTION
**Por favor, informe se a PR segue os requisitos obrigatórios:**
<!--- Exemplo checkbox marcado: - [x] -->

- [X] Mesmo padrão de código do projeto
- [ ] Arquivos alterados/adicionados seguem o padrão _Camel Case_
- [X] A PR está relacionada a uma ou mais issue
- [X] Relacionei todas as issues na seção de "Development" da PR
- [X] O código foi revisado uma vez ou mais

**Motivação para a criação da PR**
Não queremos que haja report de coverage do backend em mudanças do frontend

**O que foi feito**
Adicionado um [path filter](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore) no workflow do jacoco
