### PR TITLE
fix: adicionando construtores às entidades e adicionando log de erro

### DIFF
--- a/backend/src/main/java/com/borathings/borapagar/classroom/ClassroomEntity.java
+++ b/backend/src/main/java/com/borathings/borapagar/classroom/ClassroomEntity.java
@@ -6,12 +6,16 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 @Entity(name = "classroom")
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 @SuperBuilder(toBuilder = true)
 public class ClassroomEntity extends AbstractModel {

--- a/backend/src/main/java/com/borathings/borapagar/core/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/borathings/borapagar/core/exception/GlobalExceptionHandler.java
@@ -5,6 +5,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -17,6 +19,8 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 
 @ControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     /**
      * Constrói a resposta da exceção lançada
@@ -36,6 +40,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      */
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Object> handleGenericException(Exception ex) {
+        logger.error("Erro inesperado", ex);
         ApiException apiException =
                 new ApiException(HttpStatus.INTERNAL_SERVER_ERROR, "Erro inesperado", ex);
         return buildResponseEntityFromException(apiException);

--- a/backend/src/main/java/com/borathings/borapagar/course/CourseEntity.java
+++ b/backend/src/main/java/com/borathings/borapagar/course/CourseEntity.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
@@ -14,6 +15,7 @@ import lombok.experimental.SuperBuilder;
 @Table(name = "course")
 @Getter
 @Setter
+@NoArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 @SuperBuilder(toBuilder = true)
 public class CourseEntity extends AbstractModel {

--- a/backend/src/main/java/com/borathings/borapagar/course/CourseEntity.java
+++ b/backend/src/main/java/com/borathings/borapagar/course/CourseEntity.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,6 +17,7 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 @SuperBuilder(toBuilder = true)
 public class CourseEntity extends AbstractModel {

--- a/backend/src/main/java/com/borathings/borapagar/course/CourseRepository.java
+++ b/backend/src/main/java/com/borathings/borapagar/course/CourseRepository.java
@@ -1,5 +1,7 @@
 package com.borathings.borapagar.course;
 
 import com.borathings.borapagar.core.AbstractRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface CourseRepository extends AbstractRepository<CourseEntity> {}

--- a/backend/src/main/java/com/borathings/borapagar/subject/SubjectEntity.java
+++ b/backend/src/main/java/com/borathings/borapagar/subject/SubjectEntity.java
@@ -9,6 +9,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import java.util.Set;
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,6 +22,7 @@ import lombok.experimental.SuperBuilder;
 @Setter
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
+@AllArgsConstructor
 @SuperBuilder(toBuilder = true)
 public class SubjectEntity extends AbstractModel {
     @Column @NotNull private String name;

--- a/backend/src/main/java/com/borathings/borapagar/subject/SubjectEntity.java
+++ b/backend/src/main/java/com/borathings/borapagar/subject/SubjectEntity.java
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.NotNull;
 import java.util.Set;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
@@ -19,6 +20,7 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @Setter
 @EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
 @SuperBuilder(toBuilder = true)
 public class SubjectEntity extends AbstractModel {
     @Column @NotNull private String name;


### PR DESCRIPTION
**Por favor, informe se a PR segue os requisitos obrigatórios:**
<!--- Exemplo checkbox marcado: - [x] -->

- [x] Mesmo padrão de código do projeto
- [x] Arquivos alterados/adicionados seguem o padrão _Camel Case_
- [ ] A PR está relacionada a uma ou mais issue
- [x] Relacionei todas as issues na seção de "Development" da PR
- [x] O código foi revisado uma vez ou mais

**Motivação para a criação da PR**
<!---Descreva de maneira clara e concisa a motivação para a criação da PR na linha abaixo.-->
O construtor padrão é necessário para que o repositório recupere os dados do banco de dados. Caso contrário, uma exceção é jogada. Quando um get era feito quando o BD possuia dados, o back retornava erro 500. Este erro também não era exibido nos logs, então isso também foi implementado.

**O que foi feito**
<!---
  Se muita coisa foi feita, por favor resumir na linha abaixo.
  Exemplo:
    - Um açaí no capricho
    - Uma landing page
    - Um som que te faz dançar
-->
- Adicionado construtores novamente às entidades
- Adicionando log de qualquer exceção genérica do sistema
