### PR TITLE
feat: indicador de perfil completo/incompleto do usuário

### DIFF
--- a/backend/src/main/java/com/borathings/borapagar/user/UserEntity.java
+++ b/backend/src/main/java/com/borathings/borapagar/user/UserEntity.java
@@ -26,6 +26,7 @@ public class UserEntity extends AbstractModel {
     @Column @NotNull private String name;
     @Column @NotNull @NaturalId private String googleId;
     @Column private String imageUrl;
+    @Column @NotNull private boolean profileComplete;
 
     @Override
     public boolean equals(Object o) {

--- a/backend/src/main/java/com/borathings/borapagar/user/UserService.java
+++ b/backend/src/main/java/com/borathings/borapagar/user/UserService.java
@@ -46,6 +46,7 @@ public class UserService {
                         .name(oidcUser.getFullName())
                         .googleId(oidcUserGoogleId)
                         .imageUrl(oidcUser.getPicture())
+                        .profileComplete(false)
                         .build();
         userRepository.save(userEntity);
     }

--- a/backend/src/main/resources/db/migration/V1.20240818213922__ALTER_USER_ADD_PROFILE_COMPLETE.sql
+++ b/backend/src/main/resources/db/migration/V1.20240818213922__ALTER_USER_ADD_PROFILE_COMPLETE.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+	ADD COLUMN profile_complete boolean NOT NULL;


### PR DESCRIPTION
**Por favor, informe se a PR segue os requisitos obrigatórios:**
<!--- Exemplo checkbox marcado: - [x] -->

- [X] Mesmo padrão de código do projeto
- [X] Arquivos alterados/adicionados seguem o padrão _Camel Case_
- [ ] A PR está relacionada a uma ou mais issue
- [ ] Relacionei todas as issues na seção de "Development" da PR
- [X] O código foi revisado uma vez ou mais

**Motivação para a criação da PR**
Quando o usuário é logado, não temos acesso a dados essenciais como por exemplo seu curso, essa PR adiciona um indicador de que o perfil do usuário não está completo após o login. Permitindo que o frontend use essa informação para sugerir que o usuário complete seu perfil


**O que foi feito**
- Adicionado coluna `profile_complete` em migration nova
- Adicionado atributo `profileComplete` em UserEntity
- `profileComplete` é setado como falso no momento em que o usuário é criado


**O que faltou desenvolver**
Testes 