### PR TITLE
fix: mudando captura de exceções no service de semestre

### DIFF
--- a/backend/src/main/java/com/borathings/borapagar/user_semester/UserSemesterService.java
+++ b/backend/src/main/java/com/borathings/borapagar/user_semester/UserSemesterService.java
@@ -6,6 +6,7 @@ import com.borathings.borapagar.user_semester.dto.UserSemesterDTO;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
@@ -69,7 +70,17 @@ public class UserSemesterService {
                         .period(userSemesterDTO.getPeriod())
                         .user(authenticatedUser)
                         .build();
-        return userSemesterRepository.save(userSemesterEntity);
+
+        try {
+            userSemesterRepository.save(userSemesterEntity);
+        } catch (DataIntegrityViolationException exception) {
+            String output =
+                    String.format(
+                            "Não foi possível criar pois o semestre %d.%d já existe.",
+                            userSemesterEntity.getYear(), userSemesterEntity.getPeriod());
+            throw new DuplicateKeyException(output);
+        }
+        return userSemesterEntity;
     }
 
     /**
@@ -91,7 +102,7 @@ public class UserSemesterService {
 
         try {
             userSemesterRepository.save(userSemesterEntity);
-        } catch (DuplicateKeyException exception) {
+        } catch (DataIntegrityViolationException exception) {
             String output =
                     String.format(
                             "Não foi possível atualizar pois o semestre %d.%d já existe.",


### PR DESCRIPTION
**Por favor, informe se a PR segue os requisitos obrigatórios:**
<!--- Exemplo checkbox marcado: - [x] -->

- [x] Mesmo padrão de código do projeto
- [x] Arquivos alterados/adicionados seguem o padrão _Camel Case_
- [ ] A PR está relacionada a uma ou mais issue
- [x] Relacionei todas as issues na seção de "Development" da PR
- [x] O código foi revisado uma vez ou mais

**Motivação para a criação da PR**
<!---Descreva de maneira clara e concisa a motivação para a criação da PR na linha abaixo.-->
Antigamente no service a gente estava assumindo que o método `save` lançaria a exceção `DuplicateKeyException` em caso de uma violação da constraint `UNIQUE` no banco. Acontece que a exceção lançada é a `DataIntegrityViolationException`.

**O que foi feito**
<!---
  Se muita coisa foi feita, por favor resumir na linha abaixo.
  Exemplo:
    - Um açaí no capricho
    - Uma landing page
    - Um som que te faz dançar
-->
- Correção do tipo de exceção capturada nos métodos do `UserSemesterService`
- Atualização dos testes da classe para refletir as mudanças
