### PR TITLE
feat: possibilidade de lançar `ApiException`

### DIFF
--- a/backend/src/main/java/com/borathings/borapagar/core/exception/ApiException.java
+++ b/backend/src/main/java/com/borathings/borapagar/core/exception/ApiException.java
@@ -1,6 +1,7 @@
 package com.borathings.borapagar.core.exception;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import lombok.Data;
@@ -13,7 +14,8 @@ import org.springframework.http.HttpStatus;
  */
 @Data
 @EqualsAndHashCode(callSuper = true)
-public class ApiException extends Exception {
+@JsonIgnoreProperties({"cause", "stackTrace", "suppressed", "localizedMessage"})
+public class ApiException extends RuntimeException {
     private HttpStatus status;
     private String message;
 

--- a/backend/src/main/java/com/borathings/borapagar/core/exception/ApiException.java
+++ b/backend/src/main/java/com/borathings/borapagar/core/exception/ApiException.java
@@ -12,8 +12,8 @@ import org.springframework.http.HttpStatus;
  * a resposta de erro da API.
  */
 @Data
-@EqualsAndHashCode
-public class ApiException {
+@EqualsAndHashCode(callSuper = true)
+public class ApiException extends Exception {
     private HttpStatus status;
     private String message;
 

--- a/backend/src/main/java/com/borathings/borapagar/core/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/borathings/borapagar/core/exception/GlobalExceptionHandler.java
@@ -59,6 +59,18 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     /**
+     * Handle genérico para exceções menos comuns mas que ainda é necessário um pouco de
+     * customização na serialização.
+     *
+     * @param ex - ApiException - Exceção lançada
+     * @return ResponseEntity<Object> - Exceção serializada
+     */
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<Object> handleApiException(ApiException ex) {
+        return buildResponseEntityFromException(ex);
+    }
+
+    /**
      * Trata exceções lançadas pela aplicação quando uma entidade falha na validação. Este método
      * constrói uma instância da classe <code>ApiFieldException</code> extende a classe <code>
      * ApiException</code> com os erros de validação.


### PR DESCRIPTION
**Por favor, informe se a PR segue os requisitos obrigatórios:**
<!--- Exemplo checkbox marcado: - [x] -->

- [x] Mesmo padrão de código do projeto
- [x] Arquivos alterados/adicionados seguem o padrão _Camel Case_
- [ ] A PR está relacionada a uma ou mais issue
- [x] Relacionei todas as issues na seção de "Development" da PR
- [x] O código foi revisado uma vez ou mais

**Motivação para a criação da PR**
<!---Descreva de maneira clara e concisa a motivação para a criação da PR na linha abaixo.-->
É muito trabalhoso ter que alterar a classe do exception handler toda vez que a gente lançar um tipo de exceção nova. Além de que isso viola o princípio Open-Closed do SOLID. Essa mudança permite que a gente lance a exceção `ApiException` direto diminuindo as modificações do exception handler.

**O que foi feito**
<!---
  Se muita coisa foi feita, por favor resumir na linha abaixo.
  Exemplo:
    - Um açaí no capricho
    - Uma landing page
    - Um som que te faz dançar
-->
- ApiException agora é lançável
- Handler do ApiException
