### PR TITLE
feat(docker): adiciona camada cache para baixar dependencias

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,6 +5,10 @@ WORKDIR /app
 COPY .mvn .mvn
 COPY mvnw .
 COPY pom.xml .
+
+# Executa o Maven para baixar as dependências (Isso ajuda a aproveitar o cache do Docker)
+RUN ./mvnw dependency:go-offline
+
 COPY src src
 
 RUN ./mvnw clean install -DskipTests -P prod


### PR DESCRIPTION
**Por favor, informe se a PR segue os requisitos obrigatórios:**
<!--- Exemplo checkbox marcado: - [x] -->

- [x] Mesmo padrão de código do projeto
- [x] Arquivos alterados/adicionados seguem o padrão _Camel Case_
- [ ] A PR está relacionada a uma ou mais issue
- [ ] Relacionei todas as issues na seção de "Development" da PR
- [ ] O código foi revisado uma vez ou mais

**Motivação para a criação da PR**
<!---Descreva de maneira clara e concisa a motivação para a criação da PR na linha abaixo.-->
O build da imagem docker deve se manter otimizado para um bom CI/CD.

**O que foi feito**
<!---
  Se muita coisa foi feita, por favor resumir na linha abaixo.
  Exemplo:
    - Um açaí no capricho
    - Uma landing page
    - Um som que te faz dançar
-->
Adicionei uma camada de instalação apenas das dependências. O docker cria uma camada só para instalar essas dependências e nos próximos builds de imagem esse comando vai ser cacheado.
